### PR TITLE
fix(cicd): Triggering the docker build job when the release cicd job is complete

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -8,9 +8,11 @@ on:
   pull_request:
     branches:
       - main
-  release:
+  workflow_run:
+    workflows:
+      - "Create Release"
     types:
-      - published
+      - completed
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->
Triggering the docker build job when the release cicd job is complete

[Context](https://stackoverflow.com/questions/69063452/github-actions-on-release-created-workflow-trigger-not-working)
