### PR TITLE
chore(cicd): adding additional linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,137 @@
+linters:
+  enable:
+    - revive
+    - sloglint
+    - godox
+    - gosec
+    - musttag
+    - nilnil
+    - goconst
+    - gocritic
+    - gofmt
+    - iface
+    - thelper
+    - tparallel
+linters-settings:
+  revive:
+    # Default: false
+    ignore-generated-header: true
+    # Default: 0.8
+    confidence: 0.1
+    rules:
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#context-as-argument
+      - name: context-as-argument
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - allowTypesBefore: "*testing.T"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#early-return
+      - name: early-return
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "preserveScope"
+          - "allowJump"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-map-style
+      - name: enforce-map-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-slice-style
+      - name: enforce-slice-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#filename-format
+      - name: filename-format
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "^[_a-z][_a-z0-9]*.go$"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#optimize-operands-order
+      - name: optimize-operands-order
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+  sloglint:
+    # Enforce using attributes only (overrides no-mixed-args, incompatible with kv-only).
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#attributes-only
+    # Default: false
+    attr-only: true
+    # Enforce using static values for log messages.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#static-messages
+    # Default: false
+    static-msg: true
+    # Enforce using constants instead of raw keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-raw-keys
+    # Default: false
+    no-raw-keys: true
+    # Enforce a single key naming convention.
+    # Values: snake, kebab, camel, pascal
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#key-naming-convention
+    # Default: ""
+    key-naming-case: snake
+    # Enforce not using specific keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#forbidden-keys
+    # Default: []
+    forbidden-keys:
+      - time
+      - level
+      - msg
+      - source
+      - foo
+    # Enforce putting arguments on separate lines.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#arguments-on-separate-lines
+    # Default: false
+    args-on-sep-lines: true
+  goconst:
+    # Ignore test files.
+    # Default: false
+    ignore-tests: true
+    # Ignore when constant is not used as function argument.
+    # Default: true
+    ignore-calls: true
+    # Exclude strings matching the given regular expression.
+    # Default: ""
+    ignore-strings: ''
+  nilnil:
+    # In addition, detect opposite situation (simultaneous return of non-nil error and valid value).
+    # Default: false
+    detect-opposite: true
+    # List of return types to check.
+    # Default: ["chan", "func", "iface", "map", "ptr", "uintptr", "unsafeptr"]
+    checked-types:
+      - chan
+      - func
+      - iface
+      - map
+      - ptr
+      - uintptr
+      - unsafeptr
+  gocritic:
+    enable-all: true
+  gofmt:
+    # Simplify code: gofmt with `-s` option.
+    # Default: true
+    simplify: false
+    # Apply the rewrite rules to the source before reformatting.
+    # https://pkg.go.dev/cmd/gofmt
+    # Default: []
+    rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
+      - pattern: 'a[b:len(a)]'
+        replacement: 'a[b:]'
+  iface:
+    # List of analyzers.
+    # Default: ["identical"]
+    enable:
+      - identical # Identifies interfaces in the same package that have identical method sets.
+      - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.

--- a/encryption/crypto.go
+++ b/encryption/crypto.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-var bytes = []byte{35, 46, 57, 24, 85, 35, 24, 74, 87, 35, 88, 98, 66, 32, 14, 05}
+var bytes = []byte{35, 46, 57, 24, 85, 35, 24, 74, 87, 35, 88, 98, 66, 32, 14, 05} // nolint:gocritic // This is not a magic number
 
 func GetCryptoKey() string {
 	key := os.Getenv("CRYPT_KEY")

--- a/logging.go
+++ b/logging.go
@@ -14,7 +14,7 @@ func initializeLogger() {
 	}))
 
 	logger.With(
-		loggingKeyAppName, appName,
+		slog.String(loggingKeyAppName, appName),
 	)
 
 	slog.SetDefault(logger)
@@ -22,8 +22,7 @@ func initializeLogger() {
 
 // replaceLogAttrs is a slog.HandlerOptions.ReplaceAttr function that replaces some attributes.
 func replaceLogAttrs(_ []string, a slog.Attr) slog.Attr {
-	switch a.Key {
-	case slog.SourceKey:
+	if a.Key == slog.SourceKey {
 		// Cut the source file to a relative path.
 		v := strings.Split(a.Value.String(), "/")
 		idx := len(v) - 2

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -47,8 +48,9 @@ func (a *app) Start() {
 		r := mux.NewRouter()
 		r.HandleFunc("/metrics", promhttp.Handler().ServeHTTP)
 		srv := &http.Server{
-			Addr:    ":8080",
-			Handler: r,
+			Addr:              ":8080",
+			ReadHeaderTimeout: 10 * time.Second,
+			Handler:           r,
 		}
 		slog.Info("Starting metrics server")
 		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to improve code quality and functionality by adding new linters, addressing logging practices, and enhancing server configuration.

### Linter Configuration:
* Added multiple linters to `.golangci.yaml` including `revive`, `sloglint`, `godox`, `gosec`, `musttag`, `nilnil`, `goconst`, `gocritic`, `gofmt`, `iface`, `thelper`, and `tparallel`, along with their specific settings to enforce coding standards and best practices.

### Logging Improvements:
* Updated `logging.go` to use structured logging with `slog.String` for the `loggingKeyAppName` attribute.

### Code Quality:
* Added a `nolint` directive to suppress `gocritic` warnings for a specific byte slice in `encryption/crypto.go`.

### Server Configuration:
* Modified `main.go` to include a `ReadHeaderTimeout` of 10 seconds for the HTTP server to improve its robustness.

### Dependency Management:
* Added `time` package import in `main.go` to support the new server timeout configuration.