### PR TITLE
fix(cicd): Applying linter changes

### DIFF
--- a/.github/workflows/ci-code-approval.yml
+++ b/.github/workflows/ci-code-approval.yml
@@ -44,7 +44,7 @@ jobs:
         run: git config --global url."https://x:${GITHUB_API_TOKEN}@github.com".insteadOf "https://github.com"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: latest
           only-new-issues: true

--- a/.golangci.bck.yaml
+++ b/.golangci.bck.yaml
@@ -1,0 +1,137 @@
+linters:
+  enable:
+    - revive
+    - sloglint
+    - godox
+    - gosec
+    - musttag
+    - nilnil
+    - goconst
+    - gocritic
+    - gofmt
+    - iface
+    - thelper
+    - tparallel
+linters-settings:
+  revive:
+    # Default: false
+    ignore-generated-header: true
+    # Default: 0.8
+    confidence: 0.1
+    rules:
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#context-as-argument
+      - name: context-as-argument
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - allowTypesBefore: "*testing.T"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#early-return
+      - name: early-return
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "preserveScope"
+          - "allowJump"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-map-style
+      - name: enforce-map-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-slice-style
+      - name: enforce-slice-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#filename-format
+      - name: filename-format
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "^[_a-z][_a-z0-9]*.go$"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#optimize-operands-order
+      - name: optimize-operands-order
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+  sloglint:
+    # Enforce using attributes only (overrides no-mixed-args, incompatible with kv-only).
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#attributes-only
+    # Default: false
+    attr-only: true
+    # Enforce using static values for log messages.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#static-messages
+    # Default: false
+    static-msg: true
+    # Enforce using constants instead of raw keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-raw-keys
+    # Default: false
+    no-raw-keys: true
+    # Enforce a single key naming convention.
+    # Values: snake, kebab, camel, pascal
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#key-naming-convention
+    # Default: ""
+    key-naming-case: snake
+    # Enforce not using specific keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#forbidden-keys
+    # Default: []
+    forbidden-keys:
+      - time
+      - level
+      - msg
+      - source
+      - foo
+    # Enforce putting arguments on separate lines.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#arguments-on-separate-lines
+    # Default: false
+    args-on-sep-lines: true
+  goconst:
+    # Ignore test files.
+    # Default: false
+    ignore-tests: true
+    # Ignore when constant is not used as function argument.
+    # Default: true
+    ignore-calls: true
+    # Exclude strings matching the given regular expression.
+    # Default: ""
+    ignore-strings: ''
+  nilnil:
+    # In addition, detect opposite situation (simultaneous return of non-nil error and valid value).
+    # Default: false
+    detect-opposite: true
+    # List of return types to check.
+    # Default: ["chan", "func", "iface", "map", "ptr", "uintptr", "unsafeptr"]
+    checked-types:
+      - chan
+      - func
+      - iface
+      - map
+      - ptr
+      - uintptr
+      - unsafeptr
+  gocritic:
+    enable-all: true
+  gofmt:
+    # Simplify code: gofmt with `-s` option.
+    # Default: true
+    simplify: false
+    # Apply the rewrite rules to the source before reformatting.
+    # https://pkg.go.dev/cmd/gofmt
+    # Default: []
+    rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
+      - pattern: 'a[b:len(a)]'
+        replacement: 'a[b:]'
+  iface:
+    # List of analyzers.
+    # Default: ["identical"]
+    enable:
+      - identical # Identifies interfaces in the same package that have identical method sets.
+      - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,137 +1,122 @@
+version: "2"
 linters:
   enable:
-    - revive
-    - sloglint
-    - godox
-    - gosec
-    - musttag
-    - nilnil
     - goconst
     - gocritic
-    - gofmt
+    - godox
+    - gosec
     - iface
+    - musttag
+    - nilnil
+    - revive
+    - sloglint
     - thelper
     - tparallel
-linters-settings:
-  revive:
-    # Default: false
-    ignore-generated-header: true
-    # Default: 0.8
-    confidence: 0.1
+  settings:
+    goconst:
+      ignore-strings: ""
+      ignore-calls: true
+    gocritic:
+      enable-all: true
+    iface:
+      enable:
+        - identical
+        - unused
+    nilnil:
+      detect-opposite: true
+      checked-types:
+        - chan
+        - func
+        - iface
+        - map
+        - ptr
+        - uintptr
+        - unsafeptr
+    revive:
+      confidence: 0.1
+      rules:
+        - name: context-as-argument
+          arguments:
+            - allowTypesBefore: '*testing.T'
+          severity: error
+          disabled: false
+          exclude:
+            - ""
+        - name: early-return
+          arguments:
+            - preserveScope
+            - allowJump
+          severity: error
+          disabled: false
+          exclude:
+            - ""
+        - name: enforce-map-style
+          arguments:
+            - make
+          severity: error
+          disabled: false
+          exclude:
+            - ""
+        - name: enforce-slice-style
+          arguments:
+            - make
+          severity: error
+          disabled: false
+          exclude:
+            - ""
+        - name: filename-format
+          arguments:
+            - ^[_a-z][_a-z0-9]*.go$
+          severity: error
+          disabled: false
+          exclude:
+            - ""
+        - name: optimize-operands-order
+          severity: error
+          disabled: false
+          exclude:
+            - ""
+    sloglint:
+      attr-only: true
+      static-msg: true
+      no-raw-keys: true
+      key-naming-case: snake
+      forbidden-keys:
+        - time
+        - level
+        - msg
+        - source
+        - foo
+      args-on-sep-lines: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#context-as-argument
-      - name: context-as-argument
-        severity: error
-        disabled: false
-        exclude: [ "" ]
-        arguments:
-          - allowTypesBefore: "*testing.T"
-      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#early-return
-      - name: early-return
-        severity: error
-        disabled: false
-        exclude: [ "" ]
-        arguments:
-          - "preserveScope"
-          - "allowJump"
-      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-map-style
-      - name: enforce-map-style
-        severity: error
-        disabled: false
-        exclude: [ "" ]
-        arguments:
-          - "make"
-      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-slice-style
-      - name: enforce-slice-style
-        severity: error
-        disabled: false
-        exclude: [ "" ]
-        arguments:
-          - "make"
-      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#filename-format
-      - name: filename-format
-        severity: error
-        disabled: false
-        exclude: [ "" ]
-        arguments:
-          - "^[_a-z][_a-z0-9]*.go$"
-      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#optimize-operands-order
-      - name: optimize-operands-order
-        severity: error
-        disabled: false
-        exclude: [ "" ]
-  sloglint:
-    # Enforce using attributes only (overrides no-mixed-args, incompatible with kv-only).
-    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#attributes-only
-    # Default: false
-    attr-only: true
-    # Enforce using static values for log messages.
-    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#static-messages
-    # Default: false
-    static-msg: true
-    # Enforce using constants instead of raw keys.
-    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-raw-keys
-    # Default: false
-    no-raw-keys: true
-    # Enforce a single key naming convention.
-    # Values: snake, kebab, camel, pascal
-    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#key-naming-convention
-    # Default: ""
-    key-naming-case: snake
-    # Enforce not using specific keys.
-    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#forbidden-keys
-    # Default: []
-    forbidden-keys:
-      - time
-      - level
-      - msg
-      - source
-      - foo
-    # Enforce putting arguments on separate lines.
-    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#arguments-on-separate-lines
-    # Default: false
-    args-on-sep-lines: true
-  goconst:
-    # Ignore test files.
-    # Default: false
-    ignore-tests: true
-    # Ignore when constant is not used as function argument.
-    # Default: true
-    ignore-calls: true
-    # Exclude strings matching the given regular expression.
-    # Default: ""
-    ignore-strings: ''
-  nilnil:
-    # In addition, detect opposite situation (simultaneous return of non-nil error and valid value).
-    # Default: false
-    detect-opposite: true
-    # List of return types to check.
-    # Default: ["chan", "func", "iface", "map", "ptr", "uintptr", "unsafeptr"]
-    checked-types:
-      - chan
-      - func
-      - iface
-      - map
-      - ptr
-      - uintptr
-      - unsafeptr
-  gocritic:
-    enable-all: true
-  gofmt:
-    # Simplify code: gofmt with `-s` option.
-    # Default: true
-    simplify: false
-    # Apply the rewrite rules to the source before reformatting.
-    # https://pkg.go.dev/cmd/gofmt
-    # Default: []
-    rewrite-rules:
-      - pattern: 'interface{}'
-        replacement: 'any'
-      - pattern: 'a[b:len(a)]'
-        replacement: 'a[b:]'
-  iface:
-    # List of analyzers.
-    # Default: ["identical"]
-    enable:
-      - identical # Identifies interfaces in the same package that have identical method sets.
-      - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.
+      - linters:
+          - goconst
+        path: (.+)_test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  settings:
+    gofmt:
+      simplify: false
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any
+        - pattern: a[b:len(a)]
+          replacement: a[b:]
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/consts.go
+++ b/consts.go
@@ -3,8 +3,17 @@ package main
 const (
 	appName = "vault-unseal"
 
-	loggingKeyAppName = "app"
-	loggingKeyError   = "err"
+	loggingKeyAppName   = "app"
+	loggingKeyError     = "err"
+	loggingKeyPod       = "pod"
+	loggingKeyAddr      = "addr"
+	loggingKeyPhase     = "phase"
+	loggingKeyTaskID    = "task_id"
+	loggingKeyEventType = "event_type"
+	loggingKeyType      = "type"
+	loggingKeySignal    = "signal"
+	loggingKeySealed    = "sealed"
+	loggingKeyProgress  = "progress"
 
 	defaultKubeConfigLocation = "$HOME/.kube/config"
 	defaultTargetNamespace    = "vault"

--- a/context.go
+++ b/context.go
@@ -16,7 +16,7 @@ func getRootContext() context.Context {
 		sig := make(chan os.Signal, 1)
 		signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 		got := <-sig
-		slog.Info("Received signal, shutting down", slog.String("signal", got.String()))
+		slog.Info("Received signal, shutting down", slog.String(loggingKeySignal, got.String()))
 		cancel()
 	}()
 

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func (a *app) Start() {
 			Handler:           r,
 		}
 		slog.Info("Starting metrics server")
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) { // nolint:revive // Traditional error handling
 			slog.Error("Error starting metrics server", slog.String(loggingKeyError, err.Error()))
 			os.Exit(1)
 		}

--- a/vault.go
+++ b/vault.go
@@ -51,14 +51,16 @@ func (a *app) unsealVault(vc *api.Client) error {
 
 		slog.Info(
 			"Unsealing vault",
-			slog.Bool("sealed", resp.Sealed),
-			slog.String("progress", fmt.Sprintf("%d/%d", resp.Progress, resp.T)),
+			slog.Bool(loggingKeySealed, resp.Sealed),
+			slog.String(loggingKeyProgress, fmt.Sprintf("%d/%d", resp.Progress, resp.T)),
 		)
 
-		if !resp.Sealed {
-			slog.Info("Vault unsealed")
-			break
+		if resp.Sealed {
+			continue
 		}
+
+		slog.Info("Vault unsealed")
+		break
 	}
 
 	return nil


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several updates to improve Go linting configurations and standardize logging keys across the codebase. The most important changes include updating the Go linting action version, adding new linters and their configurations, and standardizing logging keys.

### Linting Configurations:

* [`.github/workflows/ci-code-approval.yml`](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L47-R47): Updated the `golangci-lint` action from version 6 to version 7.
* [`.golangci.bck.yaml`](diffhunk://#diff-aff4134630360fd8a117fe371f9a281f9915f722881fa770c008c84c8b29594dR1-R137): Added new linters (`revive`, `sloglint`, `godox`, `gosec`, `musttag`, `nilnil`, `goconst`, `gocritic`, `gofmt`, `iface`, `thelper`, `tparallel`) and their configurations.
* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R1-R122): Reorganized and updated the linters and their settings to match the new configurations.

### Logging Key Standardization:

* [`cluster.go`](diffhunk://#diff-556b0079cdcdaaa712eaa26594117c9d72b568bbda914495d8f46ee847f98c40L72-R73): Standardized logging keys by replacing hardcoded strings with constants for keys such as `task_id`, `event_type`, `phase`, `pod`, `addr`, `type`, and `signal`. [[1]](diffhunk://#diff-556b0079cdcdaaa712eaa26594117c9d72b568bbda914495d8f46ee847f98c40L72-R73) [[2]](diffhunk://#diff-556b0079cdcdaaa712eaa26594117c9d72b568bbda914495d8f46ee847f98c40L85-R85) [[3]](diffhunk://#diff-556b0079cdcdaaa712eaa26594117c9d72b568bbda914495d8f46ee847f98c40L101-R102) [[4]](diffhunk://#diff-556b0079cdcdaaa712eaa26594117c9d72b568bbda914495d8f46ee847f98c40L125-R137)
* [`consts.go`](diffhunk://#diff-f0067949ae0f48685cd310e00ccaf0c72d02048ccc6aeb0a862cd30b81e5e566R8-R16): Added new constants for logging keys.
* [`context.go`](diffhunk://#diff-552f47512a00afe5fc6850cc9ddc830a6daeca162750e50aab4ed549685e0253L19-R19): Updated logging to use the new `loggingKeySignal` constant.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L56-R56): Updated logging to use the new `loggingKeyError` constant and added a `nolint:revive` comment for traditional error handling.
* [`vault.go`](diffhunk://#diff-948c5baf152b678d48780c18170df98c73fc95a770816c1053ef2e1f935bafaaL54-L62): Standardized logging keys and added a `nolint:revive` comment for traditional error handling.