### PR TITLE
fix(helm): updating the cluster role

### DIFF
--- a/charts/vault-unseal/templates/clusterrole.yaml
+++ b/charts/vault-unseal/templates/clusterrole.yaml
@@ -9,3 +9,6 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "pods" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["watch", "list", "get"]


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a modification to the `rules` section in the `charts/vault-unseal/templates/clusterrole.yaml` file. The change adds permissions for endpoints to the existing rules.

Changes to permissions:

* [`charts/vault-unseal/templates/clusterrole.yaml`](diffhunk://#diff-1d867c432f64fe4adb49c07c01816833d97756b74ea66153876b3265d6eb4b7eR12-R14): Added permissions for `endpoints` to allow `watch`, `list`, and `get` verbs.