### PR TITLE
fix(unsealing): correcting the target to unseal the vault with

### DIFF
--- a/charts/vault-unseal/templates/deployment.yaml
+++ b/charts/vault-unseal/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "8080"
+        prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/vault-unseal/values.yaml
+++ b/charts/vault-unseal/values.yaml
@@ -69,17 +69,17 @@ livenessProbe:
   initialDelaySeconds: 10
   periodSeconds: 5
   tcpSocket:
-    port: 8080
+    port: 9090
 readinessProbe:
   initialDelaySeconds: 10
   periodSeconds: 5
   tcpSocket:
-    port: 8080
+    port: 9090
 startupProbe:
   initialDelaySeconds: 10
   periodSeconds: 5
   tcpSocket:
-    port: 8080
+    port: 9090
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:

--- a/cluster.go
+++ b/cluster.go
@@ -50,28 +50,25 @@ func newPodHandler(ctx context.Context, l *slog.Logger, hashBucket cache.HashBuc
 
 		pod, ok := podObj.(*core.Pod)
 		if !ok {
-			l.Warn("Object is not a pod")
 			return
 		}
 
 		if pod.GetNamespace() != targetNamespace {
-			l.Debug("Pod is not in the target namespace, ignoring")
 			return
 		}
 
 		if !hashBucket.InBucket(pod.Name) {
-			l.Debug("Pod is not in the target hash bucket, ignoring")
 			return
 		}
 
 		// Is this a vault pod?
 		if pod.Labels["app.kubernetes.io/name"] != "vault" {
-			l.Debug("Pod is not a vault pod, ignoring")
+			l.Debug("Pod is not a vault pod, ignoring", slog.String(loggingKeyPod, pod.Name))
 			return
 		}
 
 		if isSealed, _ := strconv.ParseBool(pod.Labels["vault-sealed"]); !isSealed {
-			l.Debug("Pod is not sealed, ignoring")
+			l.Debug("Pod is not sealed, ignoring", slog.String(loggingKeyPod, pod.Name))
 			return
 		}
 

--- a/cluster.go
+++ b/cluster.go
@@ -80,7 +80,7 @@ func newPodHandler(ctx context.Context, l *slog.Logger, hashBucket cache.HashBuc
 		if err := unsealNewVaultPod( // nolint:revive // Traditional error handling
 			ctx,
 			l,
-			generateVaultAddress(pod.Spec.Containers[0].Ports, pod.Status.HostIP),
+			generateVaultAddress(pod.Spec.Containers[0].Ports, pod.Status.PodIP),
 			unsealKeys,
 		); err != nil {
 			l.Error("Error unsealing vault", slog.String(loggingKeyError, err.Error()))

--- a/cluster.go
+++ b/cluster.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log/slog"
+	"strconv"
 
 	"github.com/google/uuid"
 	"github.com/jacobbrewer1/web"
@@ -64,13 +65,13 @@ func newPodHandler(ctx context.Context, l *slog.Logger, hashBucket cache.HashBuc
 		}
 
 		// Is this a vault pod?
-		if pod.Labels["app"] != "vault" {
+		if pod.Labels["app.kubernetes.io/name"] != "vault" {
 			l.Debug("Pod is not a vault pod, ignoring")
 			return
 		}
 
-		if pod.Status.Phase != core.PodPending {
-			l.Debug("Pod is not pending, ignoring as it is likely already unsealed")
+		if isSealed, _ := strconv.ParseBool(pod.Labels["vault-sealed"]); !isSealed {
+			l.Debug("Pod is not sealed, ignoring")
 			return
 		}
 

--- a/cluster.go
+++ b/cluster.go
@@ -122,7 +122,7 @@ func updatePodHandler(ctx context.Context, l *slog.Logger, hashBucket cache.Hash
 		if err := unsealNewVaultPod( // nolint:revive // Traditional error handling
 			ctx,
 			l,
-			generateVaultAddress(pod.Spec.Containers[0].Ports, pod.Status.HostIP),
+			generateVaultAddress(pod.Spec.Containers[0].Ports, pod.Status.PodIP),
 			unsealKeys,
 		); err != nil {
 			l.Error("Error unsealing vault", slog.String(loggingKeyError, err.Error()))

--- a/cluster.go
+++ b/cluster.go
@@ -69,7 +69,6 @@ func newPodHandler(ctx context.Context, l *slog.Logger, hashBucket cache.HashBuc
 			return
 		}
 		if !isVaultPodSealed(pod) {
-			l.Debug("Vault pod is already unsealed", slog.String(loggingKeyPod, pod.Name))
 			return
 		}
 
@@ -110,11 +109,10 @@ func updatePodHandler(ctx context.Context, l *slog.Logger, hashBucket cache.Hash
 			return
 		}
 		if !isVaultPodSealed(pod) {
-			l.Debug("Vault pod is already unsealed", slog.String(loggingKeyPod, pod.Name))
 			return
 		}
 
-		l.Info("New Vault pod detected, attempting to unseal vault", slog.String(loggingKeyPod, pod.Name))
+		l.Info("Updated Vault pod detected, attempting to unseal vault", slog.String(loggingKeyPod, pod.Name))
 
 		if err := unsealNewVaultPod( // nolint:revive // Traditional error handling
 			ctx,

--- a/cluster.go
+++ b/cluster.go
@@ -63,8 +63,14 @@ func newPodHandler(ctx context.Context, l *slog.Logger, hashBucket cache.HashBuc
 			return
 		}
 
-		if pod.Status.Phase != core.PodRunning {
-			l.Debug("Pod is not running, re-scheduling task")
+		// Is this a vault pod?
+		if pod.Labels["app"] != "vault" {
+			l.Debug("Pod is not a vault pod, ignoring")
+			return
+		}
+
+		if pod.Status.Phase != core.PodPending {
+			l.Debug("Pod is not pending, ignoring as it is likely already unsealed")
 			return
 		}
 

--- a/cluster.go
+++ b/cluster.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"strconv"
 
-	"github.com/google/uuid"
 	"github.com/jacobbrewer1/web"
 	"github.com/jacobbrewer1/web/cache"
 	"github.com/jacobbrewer1/web/logging"
@@ -49,15 +48,14 @@ func (a *App) watchNewPods(l *slog.Logger) web.AsyncTaskFunc {
 
 func newPodHandler(ctx context.Context, l *slog.Logger, hashBucket cache.HashBucket, unsealKeys []string) func(any) {
 	return func(podObj any) {
-		l = l.With(
-			slog.String(loggingKeyTaskID, uuid.New().String()),
-			slog.String(loggingKeyEventType, "pod"),
-		)
-
 		pod, ok := podObj.(*core.Pod)
 		if !ok {
 			return
 		}
+
+		l = l.With(
+			slog.String(loggingKeyPod, pod.Name),
+		)
 
 		if pod.GetNamespace() != targetNamespace {
 			return
@@ -91,15 +89,14 @@ func newPodHandler(ctx context.Context, l *slog.Logger, hashBucket cache.HashBuc
 
 func updatePodHandler(ctx context.Context, l *slog.Logger, hashBucket cache.HashBucket, unsealKeys []string) func(any, any) {
 	return func(_, newObj any) {
-		l = l.With(
-			slog.String(loggingKeyTaskID, uuid.New().String()),
-			slog.String(loggingKeyEventType, "pod"),
-		)
-
 		pod, ok := newObj.(*core.Pod)
 		if !ok {
 			return
 		}
+
+		l = l.With(
+			slog.String(loggingKeyPod, pod.Name),
+		)
 
 		if pod.GetNamespace() != targetNamespace {
 			return

--- a/consts.go
+++ b/consts.go
@@ -3,12 +3,10 @@ package main
 const (
 	appName = "vault-unseal"
 
-	loggingKeyError     = "err"
-	loggingKeyPod       = "pod"
-	loggingKeyTaskID    = "task_id"
-	loggingKeyEventType = "event_type"
-	loggingKeySealed    = "sealed"
-	loggingKeyProgress  = "progress"
+	loggingKeyError    = "err"
+	loggingKeyPod      = "pod"
+	loggingKeySealed   = "sealed"
+	loggingKeyProgress = "progress"
 
 	targetNamespace = "vault"
 )


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to the `vault-unseal` Helm chart and the `cluster.go` file to improve the handling of Vault pods and update port configurations.

### Helm chart updates:

* Updated the Prometheus scrape port from `8080` to `9090` in `charts/vault-unseal/templates/deployment.yaml`.
* Updated the liveness, readiness, and startup probe ports from `8080` to `9090` in `charts/vault-unseal/values.yaml`.

### Codebase updates:

* Added a new import for `strconv` in `cluster.go`.
* Added an `UpdateFunc` to the `watchNewPods` method to handle pod updates.
* Refactored the `newPodHandler` function to include additional checks for Vault pod status and namespace, and added a new `updatePodHandler` function to handle updates to Vault pods.
* Removed unused logging keys `loggingKeyTaskID` and `loggingKeyEventType` from `consts.go`.