### PR TITLE
chore(app): tidying up the vault watcher method

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -12,6 +12,8 @@ import (
 	kubeCache "k8s.io/client-go/tools/cache"
 )
 
+// watchVaultPods watches for new pods and distributes them to the correct handler that will determine if it is a
+// Vault pod. If it is, it will attempt to unseal the vault using the unseal keys provided.
 func watchVaultPods(
 	l *slog.Logger,
 	podInformer kubeCache.SharedIndexInformer,

--- a/cluster.go
+++ b/cluster.go
@@ -46,8 +46,6 @@ func watchVaultPods(
 		}
 
 		podInformer.Run(ctx.Done())
-
-		<-ctx.Done()
 	}
 }
 

--- a/cluster.go
+++ b/cluster.go
@@ -51,6 +51,8 @@ func watchVaultPods(
 	}
 }
 
+// newPodHandler is the handler for new pods. It will check if the pod is a Vault pod and if it is sealed. If it is, it
+// will attempt to unseal the vault using the unseal keys provided.
 func newPodHandler(ctx context.Context, l *slog.Logger, hashBucket cache.HashBucket, unsealKeys []string) func(any) {
 	return func(podObj any) {
 		pod, ok := podObj.(*core.Pod)
@@ -91,6 +93,8 @@ func newPodHandler(ctx context.Context, l *slog.Logger, hashBucket cache.HashBuc
 	}
 }
 
+// updatePodHandler is the handler for updated pods. It will check if the pod is a Vault pod and if it is sealed. If it
+// is, it will attempt to unseal the vault using the unseal keys provided.
 func updatePodHandler(ctx context.Context, l *slog.Logger, hashBucket cache.HashBucket, unsealKeys []string) func(any, any) {
 	return func(_, newObj any) {
 		pod, ok := newObj.(*core.Pod)
@@ -131,10 +135,12 @@ func updatePodHandler(ctx context.Context, l *slog.Logger, hashBucket cache.Hash
 	}
 }
 
+// isVaultPod checks if the pod is a Vault pod by checking the labels.
 func isVaultPod(pod *core.Pod) bool {
 	return pod.Labels["app.kubernetes.io/name"] == "vault"
 }
 
+// isVaultPodSealed checks if the pod is a Vault pod and if it is sealed by checking the labels.
 func isVaultPodSealed(pod *core.Pod) bool {
 	sealed, ok := pod.Labels["vault-sealed"]
 	if !ok {

--- a/main.go
+++ b/main.go
@@ -74,8 +74,11 @@ func (a *App) Start() error {
 			a.vaultClient = vaultClient
 			return nil
 		}),
-		web.WithIndefiniteAsyncTask("unseal-vault", a.watchNewPods(
+		web.WithIndefiniteAsyncTask("unseal-vault", watchVaultPods(
 			logging.LoggerWithComponent(a.base.Logger(), "watch-new-pods"),
+			a.base.PodInformer(),
+			a.base.ServiceEndpointHashBucket(),
+			a.config.unsealKeys,
 		)),
 	); err != nil {
 		return fmt.Errorf("failed to start web app: %w", err)


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to the `watchNewPods` function in `cluster.go` and its invocation in `main.go`. The changes involve refactoring the function to accept additional parameters directly, rather than accessing them from the `App` struct.

Refactoring `watchNewPods` function:

* [`cluster.go`](diffhunk://#diff-556b0079cdcdaaa712eaa26594117c9d72b568bbda914495d8f46ee847f98c40L15-R33): Renamed `watchNewPods` to `watchVaultPods` and modified the function to accept `podInformer`, `hashBucket`, and `unsealKeys` as parameters instead of accessing them from the `App` struct.

Updating function invocation:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L77-R81): Updated the call to `watchNewPods` to `watchVaultPods` and passed the required parameters directly from the `App` struct.