### PR TITLE
fix(app): fixing panic on pod informer

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,10 +77,8 @@ func (a *App) Start() error {
 			a.vaultClient = vaultClient
 			return nil
 		}),
-		web.WithIndefiniteAsyncTask("unseal-vault", watchVaultPods(
+		web.WithIndefiniteAsyncTask("unseal-vault", a.watchVaultPods(
 			logging.LoggerWithComponent(a.base.Logger(), "watch-new-pods"),
-			a.base.PodInformer(),
-			a.base.ServiceEndpointHashBucket(),
 			a.config.unsealKeys,
 		)),
 	); err != nil {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request refactors how the `watchVaultPods` function is implemented and integrated, transitioning it to a method of the `App` struct. This change centralizes dependencies and improves encapsulation by utilizing the `App` struct's existing fields. Below are the most important changes:

### Refactoring `watchVaultPods`:

* Converted `watchVaultPods` from a standalone function to a method of the `App` struct, allowing it to access `App`'s fields (`a.base.PodInformer()` and `a.base.ServiceEndpointHashBucket()`) instead of requiring them as parameters. This improves encapsulation and simplifies the function signature. (`cluster.go`, [cluster.goL17-R46](diffhunk://#diff-556b0079cdcdaaa712eaa26594117c9d72b568bbda914495d8f46ee847f98c40L17-R46))

* Updated the call to `watchVaultPods` in the `Start` method of the `App` struct to reflect its new method form. This ensures that the `App` instance is used to access dependencies when setting up the asynchronous task for unsealing Vault pods. (`main.go`, [main.goL80-L83](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L80-L83))