### PR TITLE
fix(keys): fixing the keys passed through

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -16,7 +16,6 @@ import (
 // Vault pod. If it is, it will attempt to unseal the vault using the unseal keys provided.
 func (a *App) watchVaultPods(
 	l *slog.Logger,
-	unsealKeys []string,
 ) web.AsyncTaskFunc {
 	return func(ctx context.Context) {
 		if _, err := a.base.PodInformer().AddEventHandler(kubeCache.ResourceEventHandlerFuncs{
@@ -24,13 +23,13 @@ func (a *App) watchVaultPods(
 				ctx,
 				logging.LoggerWithComponent(l, "new-pod-handler"),
 				a.base.ServiceEndpointHashBucket(),
-				unsealKeys,
+				a.config.unsealKeys,
 			),
 			UpdateFunc: updatePodHandler(
 				ctx,
 				logging.LoggerWithComponent(l, "update-pod-handler"),
 				a.base.ServiceEndpointHashBucket(),
-				unsealKeys,
+				a.config.unsealKeys,
 			),
 		}); err != nil {
 			l.Error("Error adding event handler", slog.String(loggingKeyError, err.Error()))

--- a/main.go
+++ b/main.go
@@ -79,7 +79,6 @@ func (a *App) Start() error {
 		}),
 		web.WithIndefiniteAsyncTask("unseal-vault", a.watchVaultPods(
 			logging.LoggerWithComponent(a.base.Logger(), "watch-new-pods"),
-			a.config.unsealKeys,
 		)),
 	); err != nil {
 		return fmt.Errorf("failed to start web app: %w", err)


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request refactors how unseal keys are passed to the `watchVaultPods` function in the `cluster.go` and `main.go` files. The changes improve maintainability by centralizing the unseal keys in the `a.config` struct instead of passing them as function arguments.

### Refactoring for unseal keys:

* [`cluster.go`](diffhunk://#diff-556b0079cdcdaaa712eaa26594117c9d72b568bbda914495d8f46ee847f98c40L19-R32): Updated the `watchVaultPods` function to use `a.config.unsealKeys` directly instead of accepting `unsealKeys` as a parameter. This change affects both the `AddFunc` and `UpdateFunc` handlers.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L82): Removed the `unsealKeys` argument from the `watchVaultPods` function call in the `Start` method, as the function now retrieves the keys from `a.config`.